### PR TITLE
CD-21768 Fix attr_encrypted not set on models

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -346,3 +346,7 @@ module AttrEncrypted
       end
   end
 end
+
+Object.extend AttrEncrypted
+
+Dir[File.join(File.dirname(__FILE__), 'attr_encrypted', 'adapters', '*.rb')].each { |adapter| require adapter }

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -26,8 +26,8 @@ if defined?(ActiveRecord::Base)
               return if new_attributes.blank?
               attributes = new_attributes.respond_to?(:with_indifferent_access) ? new_attributes.with_indifferent_access : new_attributes.symbolize_keys
               encrypted_attributes = self.class.encrypted_attributes.keys
-              self.send method, attributes.except(*encrypted_attributes), *args
-              self.send method, attributes.slice(*encrypted_attributes), *args
+              self.send method, attributes.except(*encrypted_attributes)
+              self.send method, attributes.slice(*encrypted_attributes)
             end
             private :perform_attribute_assignment
 


### PR DESCRIPTION
Changes based on https://github.com/attr-encrypted/attr_encrypted/issues/72 ,  https://github.com/attr-encrypted/attr_encrypted/pull/75  and dtaniwaki fork . 
I left the minimun changes to let the Coupa spec/features/purchase_orders/po_pcard.feature pass (CD-21768). It is saving the encrypted attributes now.